### PR TITLE
fix: ImageDefault mongo image load

### DIFF
--- a/frontend/src/Image/ImageDefault.js
+++ b/frontend/src/Image/ImageDefault.js
@@ -40,7 +40,7 @@ class ImageDefault extends React.Component {
     this.component_unmounted = true;
   };
   componentWillReceiveProps = newProps => {
-    if( newProps.src !== this.state.image_src){
+    if( newProps.src && newProps.src !== this.props.src){
       this.setState( {image_src: newProps.src, image_error: false});
     }
   };


### PR DESCRIPTION
prevent mongo image id's being used as src attrib for img tag